### PR TITLE
fix: handle CLI flags before token check

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "node --loader ts-node/esm src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "test": "node --test test/*.test.js",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,15 @@ const server = new McpServer({
   version,
 });
 
+const HELP = `Usage: justoneapi-mcp [options]
+
+MCP server for JustOneAPI.
+
+Options:
+  -h, --help       Show this help message.
+  -V, --version    Print the installed version.
+`;
+
 server.registerTool(
   "kuaishou_search_video_v2",
   {
@@ -72,6 +81,16 @@ server.registerTool(
 );
 
 async function main() {
+  const [firstArg] = process.argv.slice(2);
+  if (firstArg === "--help" || firstArg === "-h") {
+    process.stdout.write(HELP);
+    return;
+  }
+  if (firstArg === "--version" || firstArg === "-V") {
+    process.stdout.write(`${version}\n`);
+    return;
+  }
+
   // Validate configuration on startup
   if (!process.env.JUSTONEAPI_TOKEN?.trim()) {
     console.error(

--- a/test/cli-flags.test.js
+++ b/test/cli-flags.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+const bin = join(repoRoot, "dist", "index.js");
+const packageVersion = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")).version;
+
+function runCli(args) {
+  return spawnSync(process.execPath, [bin, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, JUSTONEAPI_TOKEN: "" },
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 1500,
+  });
+}
+
+test("justoneapi-mcp --help prints usage without requiring a token", () => {
+  const result = runCli(["--help"]);
+  assert.equal(result.status, 0);
+  assert.equal(result.signal, null);
+  assert.match(result.stdout, /Usage:/);
+  assert.doesNotMatch(result.stderr, /JUSTONEAPI_TOKEN is required/);
+});
+
+test("justoneapi-mcp --version prints package version without requiring a token", () => {
+  const result = runCli(["--version"]);
+  assert.equal(result.status, 0);
+  assert.equal(result.signal, null);
+  assert.equal(result.stdout.trim(), packageVersion);
+  assert.doesNotMatch(result.stderr, /JUSTONEAPI_TOKEN is required/);
+});


### PR DESCRIPTION
## Summary
- handle `--help`/`-h` and `--version`/`-V` before validating `JUSTONEAPI_TOKEN`
- add node:test coverage for both CLI flags with no token configured

## Reproduction
Published `justoneapi-mcp@1.0.1` rejects metadata flags before users can inspect help/version if `JUSTONEAPI_TOKEN` is not configured:

```text
--help status=1 stderr="[justoneapi-mcp] ERROR: JUSTONEAPI_TOKEN is required but not set..."
--version status=1 stderr="[justoneapi-mcp] ERROR: JUSTONEAPI_TOKEN is required but not set..."
```

## Verification
- `npm run build && npm test && npm run lint && npm run format:check`
- `npm pack` + clean install tarball smoke for `justoneapi-mcp --help` and `justoneapi-mcp --version` with `JUSTONEAPI_TOKEN` unset
